### PR TITLE
Always send the tag and include branch in params

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
   GHA_Meta:
     required: false
     description: 'An optional additional metadata parameter. Will be available on the CircleCI pipeline as GHA_Meta'
-  GHA_Head_SHA:
+  GHA_SHA:
     required: false
     description: 'An optional additional metadata parameter. Will be used as the tag'
 runs:

--- a/action.yml
+++ b/action.yml
@@ -7,9 +7,6 @@ inputs:
   GHA_Meta:
     required: false
     description: 'An optional additional metadata parameter. Will be available on the CircleCI pipeline as GHA_Meta'
-  GHA_SHA:
-    required: false
-    description: 'An optional additional metadata parameter. Will be used as the tag'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
   GHA_Meta:
     required: false
     description: 'An optional additional metadata parameter. Will be available on the CircleCI pipeline as GHA_Meta'
+  GHA_Head_SHA:
+    required: false
+    description: 'An optional additional metadata parameter. Will be used as the tag'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -12718,14 +12718,9 @@ const getBranch = () => {
   }
   return ref;
 };
+
 const getTag = () => {
-  const defaultBranch = _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.repository.default_branch;
-  const currentBranch = getBranch();
-  if (ref.startsWith("refs/tags/")) {
-    return ref.substring(10);
-  } else if (_actions_github__WEBPACK_IMPORTED_MODULE_1__.context.eventName === "push" && defaultBranch === currentBranch) {
-    return _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.sha;
-  }
+  return _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.sha;
 };
 
 const headers = {
@@ -12738,6 +12733,7 @@ const parameters = {
   GHA_Actor: _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.actor,
   GHA_Action: _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.action,
   GHA_Event: _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.eventName,
+  GHA_Branch: getBranch(),
 };
 
 const metaData = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)("GHA_Meta");
@@ -12750,23 +12746,14 @@ const body = {
 };
 
 const tag = getTag();
-const branch = getBranch();
 
-if (tag) {
-  Object.assign(body, { tag });
-} else {
-  Object.assign(body, { branch });
-}
+Object.assign(body, { tag: tag });
 
 const url = `https://circleci.com/api/v2/project/gh/${repoOrg}/${repoName}/pipeline`;
 
 (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`Triggering CircleCI Pipeline for ${repoOrg}/${repoName}`);
 (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`Triggering URL: ${url}`);
-if (tag) {
-  (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`Triggering tag: ${tag}`);
-} else {
-  (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`Triggering branch: ${branch}`);
-}
+(0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`Triggering tag: ${tag}`);
 (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`Parameters:\n${JSON.stringify(parameters)}`);
 (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.endGroup)();
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -12719,10 +12719,6 @@ const getBranch = () => {
   return ref;
 };
 
-const getTag = () => {
-  return _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.sha;
-};
-
 const headers = {
   "content-type": "application/json",
   "x-attribution-login": _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.actor,
@@ -12745,7 +12741,7 @@ const body = {
   parameters: parameters,
 };
 
-const tag = getTag();
+const tag = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)("GHA_Head_SHA");
 
 Object.assign(body, { tag: tag });
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -12741,7 +12741,7 @@ const body = {
   parameters: parameters,
 };
 
-const tag = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)("GHA_Head_SHA");
+const tag = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)("GHA_SHA");
 
 Object.assign(body, { tag: tag });
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -12720,12 +12720,8 @@ const getBranch = () => {
 };
 
 const getSha = () => {
-  if (ref.startsWith("refs/pull/") && headRef) {
-      return _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.pull_request.head.sha
-  } else {
-    return _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.sha
-  }
-}
+  return _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.pull_request.head.sha ?? _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.sha;
+};
 
 const headers = {
   "content-type": "application/json",

--- a/dist/index.js
+++ b/dist/index.js
@@ -12719,6 +12719,14 @@ const getBranch = () => {
   return ref;
 };
 
+const getSha = () => {
+  if (ref.startsWith("refs/pull/") && headRef) {
+      return _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.pull_request.head.sha
+  } else {
+    return _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.sha
+  }
+}
+
 const headers = {
   "content-type": "application/json",
   "x-attribution-login": _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.actor,
@@ -12741,7 +12749,7 @@ const body = {
   parameters: parameters,
 };
 
-const tag = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)("GHA_SHA");
+const tag = getSha();
 
 Object.assign(body, { tag: tag });
 

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ const body = {
   parameters: parameters,
 };
 
-const tag = getInput("GHA_Head_SHA");
+const tag = getInput("GHA_SHA");
 
 Object.assign(body, { tag: tag });
 

--- a/index.js
+++ b/index.js
@@ -27,10 +27,6 @@ const getBranch = () => {
   return ref;
 };
 
-const getTag = () => {
-  return context.sha;
-};
-
 const headers = {
   "content-type": "application/json",
   "x-attribution-login": context.actor,
@@ -53,7 +49,7 @@ const body = {
   parameters: parameters,
 };
 
-const tag = getTag();
+const tag = getInput("GHA_Head_SHA");
 
 Object.assign(body, { tag: tag });
 

--- a/index.js
+++ b/index.js
@@ -27,6 +27,14 @@ const getBranch = () => {
   return ref;
 };
 
+const getSha = () => {
+  if (ref.startsWith("refs/pull/") && headRef) {
+    return context.payload.pull_request.head.sha;
+  } else {
+    return context.sha;
+  }
+};
+
 const headers = {
   "content-type": "application/json",
   "x-attribution-login": context.actor,
@@ -49,7 +57,7 @@ const body = {
   parameters: parameters,
 };
 
-const tag = getInput("GHA_SHA");
+const tag = getSha();
 
 Object.assign(body, { tag: tag });
 

--- a/index.js
+++ b/index.js
@@ -26,14 +26,9 @@ const getBranch = () => {
   }
   return ref;
 };
+
 const getTag = () => {
-  const defaultBranch = context.payload.repository?.default_branch;
-  const currentBranch = getBranch();
-  if (ref.startsWith("refs/tags/")) {
-    return ref.substring(10);
-  } else if (context.eventName === "push" && defaultBranch === currentBranch) {
-    return context.sha;
-  }
+  return context.sha
 };
 
 const headers = {
@@ -46,6 +41,7 @@ const parameters = {
   GHA_Actor: context.actor,
   GHA_Action: context.action,
   GHA_Event: context.eventName,
+  GHA_Branch: getBranch()
 };
 
 const metaData = getInput("GHA_Meta");
@@ -58,23 +54,14 @@ const body = {
 };
 
 const tag = getTag();
-const branch = getBranch();
 
-if (tag) {
-  Object.assign(body, { tag });
-} else {
-  Object.assign(body, { branch });
-}
+Object.assign(body, { tag: tag });
 
 const url = `https://circleci.com/api/v2/project/gh/${repoOrg}/${repoName}/pipeline`;
 
 info(`Triggering CircleCI Pipeline for ${repoOrg}/${repoName}`);
 info(`Triggering URL: ${url}`);
-if (tag) {
-  info(`Triggering tag: ${tag}`);
-} else {
-  info(`Triggering branch: ${branch}`);
-}
+info(`Triggering tag: ${tag}`);
 info(`Parameters:\n${JSON.stringify(parameters)}`);
 endGroup();
 

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ const getBranch = () => {
 };
 
 const getTag = () => {
-  return context.sha
+  return context.sha;
 };
 
 const headers = {
@@ -41,7 +41,7 @@ const parameters = {
   GHA_Actor: context.actor,
   GHA_Action: context.action,
   GHA_Event: context.eventName,
-  GHA_Branch: getBranch()
+  GHA_Branch: getBranch(),
 };
 
 const metaData = getInput("GHA_Meta");

--- a/index.js
+++ b/index.js
@@ -28,11 +28,7 @@ const getBranch = () => {
 };
 
 const getSha = () => {
-  if (ref.startsWith("refs/pull/") && headRef) {
-    return context.payload.pull_request.head.sha;
-  } else {
-    return context.sha;
-  }
+  return context.payload?.pull_request?.head?.sha ?? context.sha;
 };
 
 const headers = {


### PR DESCRIPTION
With this change we will be always sending the `tag` param to CircleCI and including the `branch` in the custom params.  